### PR TITLE
Add cssAsset method to get associated css files to an asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ These assets will now be processed by Vite when running `npm run build`. You can
 <img src="<?= vite()->asset('assets/images/logo.png') ?>">
 ```
 
+## Associated CSS Files
+In some cases, you may want to include a Javascript file conditionally using the `vite()->asset()` method. Associated CSS files will not be included automatically. You can use the `vite()->assetCss()` method, which will return an array of URLs for the CSS files associated with a given asset:
+
+```php
+<?php foreach (vite()->assetCss('assets/js/my-component.js') as $cssFile): ?>
+  <link rel="stylesheet" href="<?= $cssFile ?>">
+<?php endforeach ?>
+```
+
 ## Arbitrary Attributes
 If you need to include additional attributes on your script and style tags, such as the `data-turbo-track` attribute, you may specify them via the plugin options.
 

--- a/Vite.php
+++ b/Vite.php
@@ -383,6 +383,32 @@ class Vite implements Stringable
     }
 
     /**
+     * Get URL(s) of CSS file(s) associated with an asset.
+     *
+     * @param string $asset The asset to get CSS for
+     * @param string|null $buildDirectory Optional build directory
+     * @return array Array of CSS file URLs
+     */
+    public function assetCss(string $asset, string $buildDirectory = null): array
+    {
+        $buildDirectory ??= $this->buildDirectory;
+
+        if ($this->isRunningHot()) {
+            return [];
+        }
+
+        $chunk = $this->chunk($this->manifest($buildDirectory), $asset);
+        $cssFiles = [];
+
+        // Get direct CSS files
+        foreach ($chunk['css'] ?? [] as $cssFile) {
+            $cssFiles[] = url($buildDirectory . '/' . $cssFile);
+        }
+
+        return $cssFiles;
+    }
+
+    /**
      * Generate React refresh runtime script.
      */
     public function reactRefresh(): string


### PR DESCRIPTION
Hey @lukaskleinschmidt, 
thank you very much for this plugin!

I have a small feature request that I hope you might consider. I've a built a plugin called [kirby-asset-manager](https://github.com/femundfilou/kirby-asset-manager) that allows one to include assets on a snippet / block level. I use this to minimize the css / js files on the page, if a certain block is not being used. 

To get the urls from Vite, I use the asset method from your plugin like so:

```php
$assetManager->add('js', vite()->asset('frontend/blocks/key-visual/key-visual.ts'), ['data-taxi-reload', 'type' => 'module']);
```

That works perfectly, but there is one issue when using more complex components (e.g. Svelte). On built, Vite will extract the css into it's own files that are associated with the asset itself.

```json
  "frontend/blocks/key-visual/key-visual.ts": {
    "file": "assets/key-visual-DOfCgXsk.js",
    "name": "key-visual",
    "src": "frontend/blocks/key-visual/key-visual.ts",
    "isEntry": true,
    "imports": [
      "frontend/blocks/key-visual/store/layers.svelte.ts"
    ],
    "css": [
      "assets/key-visual-CoRjIvEW.css"
    ]
  }
 ```
 
 Using the `vite()->asset()` method alone, will only return the javascript file, which is expected. This is why I added a `vite()->assetCss()` method to resolve the `css` array on those files.
 
 ```php
 $assetManager->add('js', vite()->asset('frontend/blocks/key-visual/key-visual.ts'), ['data-taxi-reload', 'type' => 'module']);

foreach (vite()->assetCss('frontend/blocks/key-visual/key-visual.ts') as $cssFile):
	$assetManager->add('css', $cssFile);
endforeach;
```