### PR TITLE
docs: make plugin name clickable in kirby panel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "lukaskleinschmidt/kirby-laravel-vite",
 	"description": "Kirby Laravel Vite",
 	"license": "MIT",
-    "homepage": "https://github.com/lukaskleinschmidt/kirby-laravel-vite#readme",
+	"homepage": "https://github.com/lukaskleinschmidt/kirby-laravel-vite#readme",
 	"type": "kirby-plugin",
 	"authors": [
 		{
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-        "php": "^8.2",
+				"php": "^8.2",
 		"getkirby/composer-installer": "^1.2"
 	},
 	"config": {
@@ -19,7 +19,7 @@
 			"getkirby/composer-installer": true
 		}
 	},
-    "extra": {
-        "installer-name": "laravel-vite"
-    }
+		"extra": {
+				"installer-name": "laravel-vite"
+		}
 }

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name": "lukaskleinschmidt/kirby-laravel-vite",
 	"description": "Kirby Laravel Vite",
 	"license": "MIT",
+    "homepage": "https://github.com/lukaskleinschmidt/kirby-laravel-vite#readme",
 	"type": "kirby-plugin",
 	"authors": [
 		{


### PR DESCRIPTION
To be able to click on the plugin name in the Kirby panel, there needs to be a homepage in `composer.json`.

Also, fixed inconsistent indentation (converting everything to Tabs).